### PR TITLE
10: Encrypt/decrypt udfs with a managed agent cache

### DIFF
--- a/src/main/java/io/github/turtlemonvh/ionicsparkutils/TestAgent.java
+++ b/src/main/java/io/github/turtlemonvh/ionicsparkutils/TestAgent.java
@@ -27,14 +27,10 @@ import com.ionic.sdk.cipher.aes.AesCipher;
 
 import java.io.Serializable;
 import java.security.SecureRandom;
-import java.util.HashMap;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.Set;
 import java.util.UUID;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.HashSet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/scala/io/github/turtlemonvh/ionicsparkutils/Udfs.scala
+++ b/src/main/scala/io/github/turtlemonvh/ionicsparkutils/Udfs.scala
@@ -1,0 +1,60 @@
+package io.github.turtlemonvh.ionicsparkutils
+
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.internal.Logging
+
+import com.ionic.sdk.key.KeyServices
+import com.ionic.sdk.agent.cipher.chunk.ChunkCipherV3
+import scala.collection.mutable.{ Map, SynchronizedMap, HashMap }
+
+import java.io.Serializable;
+import java.util.concurrent.ConcurrentHashMap;
+import collection.JavaConverters._
+
+/*
+ * Encrypt and decrypt using cached key services objects.
+ *
+ */
+object Udfs extends Logging with Serializable {
+
+  // Object for saving the chunk cipher along with the agent
+  case class CachedAgent(agent: KeyServices, cc: ChunkCipherV3)
+
+  // Synchronized agent pool cache
+  var Agents = new ConcurrentHashMap[String, CachedAgent]
+
+  def AddAgentWithId(agent: KeyServices, agentId: String) = {
+    Agents.put(agentId, CachedAgent(agent, new ChunkCipherV3(agent)))
+  }
+
+  def getDefaultAgentId(): String = {
+    Agents.keys.nextElement
+  }
+
+  def EncryptWith(in: String, agentId: String): String = {
+    val agent = Agents.get(agentId)
+    if (agent == null) {
+      logError(s"No agent found for id: ${agentId}. Known agent ids: ${Agents.keys.asScala}")
+    }
+    agent.cc.encrypt(in)
+  }
+  def Encrypt(in: String): String = {
+    EncryptWith(in, getDefaultAgentId)
+  }
+  val UDFEncryptWith = udf(EncryptWith _)
+  val UDFEncrypt = udf(Encrypt _)
+
+  def DecryptWith(in: String, agentId: String): String = {
+    val agent = Agents.get(agentId)
+    if (agent == null) {
+      logError(s"No agent found for id: ${agentId}. Known agent ids: ${Agents.keys.asScala}")
+    }
+    agent.cc.decrypt(in)
+  }
+  def Decrypt(in: String): String = {
+    DecryptWith(in, getDefaultAgentId)
+  }
+  val UDFDecryptWith = udf(DecryptWith _)
+  val UDFDecrypt = udf(Decrypt _)
+
+}

--- a/src/test/scala/io/github/turtlemonvh/ionicsparkutils/TransformersTest.scala
+++ b/src/test/scala/io/github/turtlemonvh/ionicsparkutils/TransformersTest.scala
@@ -4,8 +4,7 @@ package io.github.turtlemonvh.ionicsparkutils
  * A simple test of a spark transformer.
  */
 
-import com.holdenkarau.spark.testing.{ DataFrameSuiteBase }
-import com.holdenkarau.spark.testing.SharedSparkContext
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
 import org.scalatest.FunSuite
 
 import com.ionic.sdk.agent.cipher.chunk.ChunkCipherV3

--- a/src/test/scala/io/github/turtlemonvh/ionicsparkutils/UdfsTest.scala
+++ b/src/test/scala/io/github/turtlemonvh/ionicsparkutils/UdfsTest.scala
@@ -1,0 +1,56 @@
+package io.github.turtlemonvh.ionicsparkutils
+
+import com.holdenkarau.spark.testing.DataFrameSuiteBase
+import org.scalatest.FunSuite
+import org.apache.spark.sql.types._
+
+/*
+ * Test encryption and decryption operations with udf operations using cached key services objects.
+ */
+class UdfsTest extends FunSuite with DataFrameSuiteBase {
+  import spark.implicits._
+
+  test("encrypt") {
+    // Create df and put into sql view
+    val inputDF = Seq(
+      ("bob", "tomato"),
+      ("larry", "cucumber")).toDF("name", "plant_type")
+    inputDF.createOrReplaceTempView("veggietales")
+
+    // Pre-seed agent cache
+    val a = new KeyServicesCache(new TestAgent())
+    for (i <- 1 to 10) {
+      a.createKey()
+    }
+    a.makeImmutable
+
+    // Populate the agent cache
+    Udfs.AddAgentWithId(a, "testAgent")
+
+    // Populate the udf function registry
+    spark.udf.register("ionicenc", Udfs.UDFEncrypt)
+    spark.udf.register("ionicencw", Udfs.UDFEncryptWith)
+    spark.udf.register("ionicdec", Udfs.UDFDecrypt)
+    spark.udf.register("ionicdecw", Udfs.UDFDecryptWith)
+
+    // Encrypt
+    val encDF = spark.sql("SELECT name, ionicencw(plant_type, 'testAgent') as encrypted_plant_type FROM veggietales")
+    encDF.show
+
+    // Encrypt with default
+    val encDefDF = spark.sql("SELECT name, ionicenc(plant_type) as encrypted_plant_type FROM veggietales")
+    encDefDF.show
+
+    // Save encrypted view for use in decrypt tests
+    encDF.createOrReplaceTempView("enc_veggietales")
+
+    // Decrypt
+    val decDF = spark.sql("SELECT name, ionicdecw(encrypted_plant_type, 'testAgent') as encrypted_plant_type FROM enc_veggietales")
+    decDF.show
+
+    // Decrypt with default
+    val decDefDF = spark.sql("SELECT name, ionicdec(encrypted_plant_type) as encrypted_plant_type FROM enc_veggietales")
+    decDefDF.show
+
+  }
+}


### PR DESCRIPTION
Will resolve #10.

Still TODO

* Shift from passing agents to the `agentFactory` method used by transformers (so `agentFactory` is called on each worker node)
* Update the tests to check for correct values rather than just lack of error
* Consider cleaning up the agent cache implementation. Current interface is ugly.